### PR TITLE
Making last letter of "basic interactivity" visible

### DIFF
--- a/screen1.svg
+++ b/screen1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<svg width="1920" height="1400" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+<svg width="1920" height="1420" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
  <defs>
   <!-- <style>line, .video, .exercise, .lecture, .milestone, polyline {
             stroke: #000000;


### PR DESCRIPTION
The last letter of "basic interactivity" is not visible on the bottom of the website